### PR TITLE
Fix analyze button with Neon dappkit

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,39 +1,25 @@
-import { OpToken, OpCodePrices, OpCode } from "@cityofzion/neon-core/lib/sc";
+import { rpc, sc } from "@cityofzion/neon-core";
+import { NeonParser } from "@cityofzion/neon-dappkit";
 
 const form = document.getElementById('tx-form');
 const output = document.getElementById('output');
 const RPC_ENDPOINT = 'https://node.neodepot.org/';
-
-function hexFromBase64(b64) {
-  const bytes = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
-  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
-}
+const rpcClient = new rpc.RPCClient(RPC_ENDPOINT);
 
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
   const txid = document.getElementById('txid').value.trim();
   output.textContent = 'Loading...';
   try {
-    const body = {
-      jsonrpc: '2.0',
-      method: 'getrawtransaction',
-      params: [txid, 1],
-      id: 1
-    };
-    const resp = await fetch(RPC_ENDPOINT, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body)
-    });
-    const data = await resp.json();
-    if (!data.result) throw new Error(data.error?.message || 'No result');
-    const hex = hexFromBase64(data.result.script);
-    const tokens = OpToken.fromScript(hex);
+    const data = await rpcClient.getRawTransaction(txid, true);
+    if (!data || !data.script) throw new Error('No result');
+    const hex = NeonParser.base64ToHex(data.script);
+    const tokens = sc.OpToken.fromScript(hex);
     let total = 0;
     const lines = tokens.map(t => {
-      const price = OpCodePrices[t.code] || 0;
+      const price = sc.OpCodePrices[t.code] || 0;
       total += price;
-      const name = OpCode[t.code];
+      const name = sc.OpCode[t.code];
       const params = t.params ? ' ' + t.params : '';
       return `${name}${params} -> ${price} GAS`;
     });


### PR DESCRIPTION
## Summary
- fetch transactions using `neon-core` RPC client
- decode results via `NeonParser`
- simplify opcode imports from `neon-core`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6881484912fc832fb9c1deb9f21c2e16