### PR TITLE
Fix module imports for static deployment

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
-import { rpc, sc } from "@cityofzion/neon-js";
-import { NeonParser } from "@cityofzion/neon-dappkit";
+import { rpc, sc } from "https://esm.sh/@cityofzion/neon-js@5.7.0";
+import { NeonParser } from "https://esm.sh/@cityofzion/neon-dappkit@0.6.0";
 
 const form = document.getElementById('tx-form');
 const output = document.getElementById('output');


### PR DESCRIPTION
## Summary
- load `neon-js` and `neon-dappkit` from `esm.sh`

## Testing
- `npm install`
- `npm run build`
- `npx serve -l 5000` *(in background)*
- `node test.js` *(using puppeteer to ensure no module specifier errors)*

------
https://chatgpt.com/codex/tasks/task_e_68814f534e44832f99f3022121b6c13e