### PR TITLE
Fix Neon imports for ESM

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,7 @@
-import { rpc, sc } from "@cityofzion/neon-js";
-import { NeonParser } from "@cityofzion/neon-dappkit";
+import Neon from "https://esm.sh/@cityofzion/neon-js@5.7.0";
+import { NeonParser } from "https://esm.sh/@cityofzion/neon-dappkit@0.6.0";
+
+const { rpc, sc } = Neon;
 
 const form = document.getElementById('tx-form');
 const output = document.getElementById('output');


### PR DESCRIPTION
## Summary
- import `neon-js` default export and destructure `rpc` and `sc`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68814f534e44832f99f3022121b6c13e